### PR TITLE
Mirror of aws amazon-freertos#1381

### DIFF
--- a/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
+++ b/libraries/abstractions/ble_hal/test/src/iot_test_ble_hal_integration.c
@@ -463,6 +463,9 @@ void prvGAPInitEnableTwice()
     TEST_ASSERT_EQUAL( eBTstateOn, xInitDeinitCb.xBLEState );
     TEST_ASSERT_LESS_THAN( CLOCKS_PER_SEC * 5, ( cbRecvTime - returnTime ) * 2 );
 
+    /* First time disable */
+    IotTestBleHal_BLEEnable( false );
+
     /*First time Deinit*/
     xStatus = _pxBTInterface->pxBtManagerCleanup();
     TEST_ASSERT_EQUAL( eBTStatusSuccess, xStatus );

--- a/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
@@ -182,6 +182,7 @@ static void prvMiscInitialization( void )
         esp_err_t xBLEStackTeardown( void )
         {
             esp_err_t xRet;
+
             xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BLE );
 
             if( xRet == ESP_OK )

--- a/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
@@ -90,6 +90,8 @@ static void prvMiscInitialization( void );
 #if BLE_ENABLED
 /* Initializes bluetooth */
     static esp_err_t prvBLEStackInit( void );
+    /** Helper function to teardown BLE stack. **/
+    esp_err_t xBLEStackTeardown( void );
     static void spp_uart_init( void );
 #endif
 
@@ -173,10 +175,19 @@ static void prvMiscInitialization( void )
     #if CONFIG_NIMBLE_ENABLED == 1
         esp_err_t prvBLEStackInit( void )
         {
-            /* Initialize BLE */
-            esp_err_t xRet = ESP_OK;
+            return ESP_OK;
+        }
 
-            xRet = esp_nimble_hci_and_controller_init();
+
+        esp_err_t xBLEStackTeardown( void )
+        {
+            esp_err_t xRet;
+            xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BLE );
+
+            if( xRet == ESP_OK )
+            {
+                xRet =esp_bt_controller_mem_release( ESP_BT_MODE_BTDM );
+            }
 
             return xRet;
         }
@@ -215,6 +226,46 @@ static void prvMiscInitialization( void )
             if( xRet == ESP_OK )
             {
                 xRet = esp_bluedroid_enable();
+            }
+
+            return xRet;
+        }
+
+        esp_err_t xBLEStackTeardown( void )
+        {
+            esp_err_t xRet = ESP_OK;
+
+            if( esp_bluedroid_get_status() == ESP_BLUEDROID_STATUS_ENABLED )
+            {
+                xRet = esp_bluedroid_disable();
+            }
+
+            if( xRet == ESP_OK )
+            {
+                xRet = esp_bluedorid_deinit();
+            }
+
+            if( xRet == ESP_OK )
+            {
+                if( esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED )
+                {
+                    xRet = esp_bt_controller_disable();
+                }
+            }
+
+            if( xRet == ESP_OK )
+            {
+                xRet = esp_bt_controller_deinit();
+            }
+
+            if( xRet == ESP_OK )
+            {
+                xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BLE );
+            }
+
+            if( xRet == ESP_OK )
+            {
+                xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BTDM );
             }
 
             return xRet;

--- a/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_demos/application_code/main.c
@@ -186,7 +186,7 @@ static void prvMiscInitialization( void )
 
             if( xRet == ESP_OK )
             {
-                xRet =esp_bt_controller_mem_release( ESP_BT_MODE_BTDM );
+                xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BTDM );
             }
 
             return xRet;
@@ -196,39 +196,7 @@ static void prvMiscInitialization( void )
 
         static esp_err_t prvBLEStackInit( void )
         {
-            /* Initialize BLE */
-            esp_err_t xRet = ESP_OK;
-            esp_bt_controller_config_t xBtCfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-
-
-            ESP_ERROR_CHECK( esp_bt_controller_mem_release( ESP_BT_MODE_CLASSIC_BT ) );
-
-            xRet = esp_bt_controller_init( &xBtCfg );
-
-            if( xRet == ESP_OK )
-            {
-                xRet = esp_bt_controller_enable( ESP_BT_MODE_BLE );
-            }
-            else
-            {
-                configPRINTF( ( "Failed to initialize bt controller, err = %d", xRet ) );
-            }
-
-            if( xRet == ESP_OK )
-            {
-                xRet = esp_bluedroid_init();
-            }
-            else
-            {
-                configPRINTF( ( "Failed to initialize bluedroid stack, err = %d", xRet ) );
-            }
-
-            if( xRet == ESP_OK )
-            {
-                xRet = esp_bluedroid_enable();
-            }
-
-            return xRet;
+            return ESP_OK;
         }
 
         esp_err_t xBLEStackTeardown( void )
@@ -242,7 +210,7 @@ static void prvMiscInitialization( void )
 
             if( xRet == ESP_OK )
             {
-                xRet = esp_bluedorid_deinit();
+                xRet = esp_bluedroid_deinit();
             }
 
             if( xRet == ESP_OK )

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
@@ -202,6 +202,7 @@ static void prvMiscInitialization( void )
         /* Release BT memory as it is not used. */
         ESP_ERROR_CHECK( esp_bt_controller_mem_release( ESP_BT_MODE_CLASSIC_BT ) );
     #endif
+
     ESP_ERROR_CHECK( ret );
 }
 /*-----------------------------------------------------------*/
@@ -323,19 +324,22 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
 #if CONFIG_NIMBLE_ENABLED == 1
     BTStatus_t bleStackInit( void )
     {
-        /* Initialize BLE */
-        esp_err_t xRet = ESP_OK;
-        BTStatus_t status = eBTStatusFail;
+        return eBTStatusSuccess;
+    }
 
-        xRet = esp_nimble_hci_and_controller_init();
+    esp_err_t bleStackTeardown( void )
+    {
+        esp_err_t xRet;
+        xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BLE );
 
         if( xRet == ESP_OK )
         {
-            status = eBTStatusSuccess;
+            xRet =esp_bt_controller_mem_release( ESP_BT_MODE_BTDM );
         }
 
-        return status;
+        return xRet;
     }
+
 
 #else  /* if CONFIG_NIMBLE_ENABLED == 1 */
 
@@ -349,8 +353,8 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
         esp_bt_controller_config_t xBtCfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
         BTStatus_t status = eBTStatusFail;
 
-        configPRINTF( ( "Initializing BLE stack.\n" ) );
 
+        configPRINTF( ( "Initializing BLE stack.\n" ) );
 
         xRet = esp_bt_controller_init( &xBtCfg );
 
@@ -383,5 +387,45 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
         }
 
         return status;
+    }
+
+    esp_err_t bleStackTeardown( void )
+    {
+        esp_err_t xRet = ESP_OK;
+
+        if( esp_bluedroid_get_status() == ESP_BLUEDROID_STATUS_ENABLED )
+        {
+            xRet = esp_bluedroid_disable();
+        }
+
+        if( xRet == ESP_OK )
+        {
+            xRet = esp_bluedorid_deinit();
+        }
+
+        if( xRet == ESP_OK )
+        {
+            if( esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED )
+            {
+                xRet = esp_bt_controller_disable();
+            }
+        }
+
+        if( xRet == ESP_OK )
+        {
+            xRet = esp_bt_controller_deinit();
+        }
+
+        if( xRet == ESP_OK )
+        {
+            xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BLE );
+        }
+
+        if( xRet == ESP_OK )
+        {
+            xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BTDM );
+        }
+
+        return xRet;
     }
 #endif /* if CONFIG_NIMBLE_ENABLED == 1 */

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
@@ -330,6 +330,7 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
     esp_err_t bleStackTeardown( void )
     {
         esp_err_t xRet;
+
         xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BLE );
 
         if( xRet == ESP_OK )
@@ -341,14 +342,14 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
     }
 
 
-#else  /* if CONFIG_NIMBLE_ENABLED == 1 */
+#else /* if CONFIG_NIMBLE_ENABLED == 1 */
 
 /*
  * Return on success
  */
     BTStatus_t bleStackInit( void )
     {
-       return eBTStatusSuccess;
+        return eBTStatusSuccess;
     }
 
     esp_err_t bleStackTeardown( void )

--- a/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
+++ b/vendors/espressif/boards/esp32/aws_tests/application_code/main.c
@@ -334,7 +334,7 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
 
         if( xRet == ESP_OK )
         {
-            xRet =esp_bt_controller_mem_release( ESP_BT_MODE_BTDM );
+            xRet = esp_bt_controller_mem_release( ESP_BT_MODE_BTDM );
         }
 
         return xRet;
@@ -348,45 +348,7 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
  */
     BTStatus_t bleStackInit( void )
     {
-        /* Initialize BLE */
-        esp_err_t xRet = ESP_OK;
-        esp_bt_controller_config_t xBtCfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-        BTStatus_t status = eBTStatusFail;
-
-
-        configPRINTF( ( "Initializing BLE stack.\n" ) );
-
-        xRet = esp_bt_controller_init( &xBtCfg );
-
-        if( xRet == ESP_OK )
-        {
-            xRet = esp_bt_controller_enable( ESP_BT_MODE_BLE );
-        }
-        else
-        {
-            configPRINTF( ( "Failed to initialize bt controller, err = %d.\n", xRet ) );
-        }
-
-        if( xRet == ESP_OK )
-        {
-            xRet = esp_bluedroid_init();
-        }
-        else
-        {
-            configPRINTF( ( "Failed to initialize bluedroid stack, err = %d.\n", xRet ) );
-        }
-
-        if( xRet == ESP_OK )
-        {
-            xRet = esp_bluedroid_enable();
-        }
-
-        if( xRet == ESP_OK )
-        {
-            status = eBTStatusSuccess;
-        }
-
-        return status;
+       return eBTStatusSuccess;
     }
 
     esp_err_t bleStackTeardown( void )
@@ -400,7 +362,7 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
 
         if( xRet == ESP_OK )
         {
-            xRet = esp_bluedorid_deinit();
+            xRet = esp_bluedroid_deinit();
         }
 
         if( xRet == ESP_OK )

--- a/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_common_gap.c
@@ -527,12 +527,8 @@ BTStatus_t prvBTManagerInit( const BTCallbacks_t * pxCallbacks )
 
 BTStatus_t prvBtManagerCleanup()
 {
-    BTStatus_t xStatus = eBTStatusSuccess;
 
-    esp_bt_controller_mem_release( ESP_BT_MODE_BLE );
-    esp_bt_controller_mem_release( ESP_BT_MODE_BTDM );
-
-    return xStatus;
+    return eBTStatusSuccess;
 }
 
 /*-----------------------------------------------------------*/
@@ -566,7 +562,7 @@ BTStatus_t prvBTDisable()
 {
     BTStatus_t xStatus = eBTStatusSuccess;
 
-    if( esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_ENABLED )
+    if( esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED )
     {
         if( esp_bt_controller_disable() != ESP_OK )
         {

--- a/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_common_gap.c
@@ -510,6 +510,7 @@ BTSecurityLevel_t prvConvertESPauthModeToSecurityLevel( esp_ble_auth_req_t xAuth
 BTStatus_t prvBTManagerInit( const BTCallbacks_t * pxCallbacks )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
+    /* Initialize BLE */
 
     if( pxCallbacks != NULL )
     {
@@ -536,13 +537,37 @@ BTStatus_t prvBtManagerCleanup()
 BTStatus_t prvBTEnable( uint8_t ucGuestMode )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
+    esp_err_t xRet = ESP_OK;
+    esp_bt_controller_config_t xBtCfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
 
-    if( esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_ENABLED )
+    xRet = esp_bt_controller_init( &xBtCfg );
+
+    if( xRet == ESP_OK )
     {
-        if( esp_bt_controller_enable( ESP_BT_MODE_BLE ) != ESP_OK )
-        {
-            xStatus = eBTStatusFail;
-        }
+    	xRet = esp_bt_controller_enable( ESP_BT_MODE_BLE );
+    }
+    else
+    {
+    	configPRINTF( ( "Failed to initialize bt controller, err = %d.\n", xRet ) );
+    }
+
+    if( xRet == ESP_OK )
+    {
+    	xRet = esp_bluedroid_init();
+    }
+    else
+    {
+    	configPRINTF( ( "Failed to initialize bluedroid stack, err = %d.\n", xRet ) );
+    }
+
+    if( xRet == ESP_OK )
+    {
+    	xRet = esp_bluedroid_enable();
+    }
+
+    if( xRet != ESP_OK )
+    {
+    	xStatus = eBTStatusFail;
     }
 
     /** If status is ok and callback is set, trigger the callback.
@@ -561,13 +586,34 @@ BTStatus_t prvBTEnable( uint8_t ucGuestMode )
 BTStatus_t prvBTDisable()
 {
     BTStatus_t xStatus = eBTStatusSuccess;
+    esp_err_t xRet = ESP_OK;
 
-    if( esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED )
+    if( esp_bluedroid_get_status() == ESP_BLUEDROID_STATUS_ENABLED )
     {
-        if( esp_bt_controller_disable() != ESP_OK )
-        {
-            xStatus = eBTStatusFail;
-        }
+    	xRet = esp_bluedroid_disable();
+    }
+
+    if( xRet == ESP_OK )
+    {
+    	xRet = esp_bluedroid_deinit();
+    }
+
+    if( xRet == ESP_OK )
+    {
+    	if( esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED )
+    	{
+    		xRet = esp_bt_controller_disable();
+    	}
+    }
+
+    if( xRet == ESP_OK )
+    {
+    	xRet = esp_bt_controller_deinit();
+    }
+
+    if( xRet != ESP_OK )
+    {
+    	xStatus = eBTStatusFail;
     }
 
     /** If status is ok and callback is set, trigger the callback.

--- a/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/bluedroid/iot_ble_hal_common_gap.c
@@ -510,6 +510,7 @@ BTSecurityLevel_t prvConvertESPauthModeToSecurityLevel( esp_ble_auth_req_t xAuth
 BTStatus_t prvBTManagerInit( const BTCallbacks_t * pxCallbacks )
 {
     BTStatus_t xStatus = eBTStatusSuccess;
+
     /* Initialize BLE */
 
     if( pxCallbacks != NULL )
@@ -528,7 +529,6 @@ BTStatus_t prvBTManagerInit( const BTCallbacks_t * pxCallbacks )
 
 BTStatus_t prvBtManagerCleanup()
 {
-
     return eBTStatusSuccess;
 }
 
@@ -544,30 +544,30 @@ BTStatus_t prvBTEnable( uint8_t ucGuestMode )
 
     if( xRet == ESP_OK )
     {
-    	xRet = esp_bt_controller_enable( ESP_BT_MODE_BLE );
+        xRet = esp_bt_controller_enable( ESP_BT_MODE_BLE );
     }
     else
     {
-    	configPRINTF( ( "Failed to initialize bt controller, err = %d.\n", xRet ) );
+        configPRINTF( ( "Failed to initialize bt controller, err = %d.\n", xRet ) );
     }
 
     if( xRet == ESP_OK )
     {
-    	xRet = esp_bluedroid_init();
+        xRet = esp_bluedroid_init();
     }
     else
     {
-    	configPRINTF( ( "Failed to initialize bluedroid stack, err = %d.\n", xRet ) );
+        configPRINTF( ( "Failed to initialize bluedroid stack, err = %d.\n", xRet ) );
     }
 
     if( xRet == ESP_OK )
     {
-    	xRet = esp_bluedroid_enable();
+        xRet = esp_bluedroid_enable();
     }
 
     if( xRet != ESP_OK )
     {
-    	xStatus = eBTStatusFail;
+        xStatus = eBTStatusFail;
     }
 
     /** If status is ok and callback is set, trigger the callback.
@@ -590,30 +590,30 @@ BTStatus_t prvBTDisable()
 
     if( esp_bluedroid_get_status() == ESP_BLUEDROID_STATUS_ENABLED )
     {
-    	xRet = esp_bluedroid_disable();
+        xRet = esp_bluedroid_disable();
     }
 
     if( xRet == ESP_OK )
     {
-    	xRet = esp_bluedroid_deinit();
+        xRet = esp_bluedroid_deinit();
     }
 
     if( xRet == ESP_OK )
     {
-    	if( esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED )
-    	{
-    		xRet = esp_bt_controller_disable();
-    	}
+        if( esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED )
+        {
+            xRet = esp_bt_controller_disable();
+        }
     }
 
     if( xRet == ESP_OK )
     {
-    	xRet = esp_bt_controller_deinit();
+        xRet = esp_bt_controller_deinit();
     }
 
     if( xRet != ESP_OK )
     {
-    	xStatus = eBTStatusFail;
+        xStatus = eBTStatusFail;
     }
 
     /** If status is ok and callback is set, trigger the callback.

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
@@ -529,6 +529,7 @@ BTStatus_t prvBTManagerInit( const BTCallbacks_t * pxCallbacks )
 
 
     xRet = esp_nimble_hci_and_controller_init();
+
     if( xRet == ESP_OK )
     {
         if( pxCallbacks != NULL )
@@ -539,26 +540,22 @@ BTStatus_t prvBTManagerInit( const BTCallbacks_t * pxCallbacks )
         {
             xStatus = eBTStatusFail;
         }
-
     }
     else
     {
         xStatus = eBTStatusFail;
     }
 
-
     if( xStatus == eBTStatusSuccess )
     {
-
         ble_hs_cfg.reset_cb = bleprph_on_reset;
         ble_hs_cfg.sync_cb = bleprph_on_sync;
         ble_hs_cfg.store_status_cb = ble_store_util_status_rr;
 
         ble_store_config_init();
     }
-    
-    return xStatus;
 
+    return xStatus;
 }
 
 /*-----------------------------------------------------------*/
@@ -569,6 +566,7 @@ BTStatus_t prvBtManagerCleanup()
     BTStatus_t xStatus = eBTStatusSuccess;
 
     xRet = esp_nimble_hci_and_controller_deinit();
+
     if( xRet != ESP_OK )
     {
         ESP_LOGE( TAG, "esp_nimble_hci_and_controller_deinit() failed with error %d", xRet );

--- a/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
+++ b/vendors/espressif/boards/esp32/ports/ble/nimble/iot_ble_hal_common_gap.c
@@ -550,11 +550,10 @@ BTStatus_t prvBTManagerInit( const BTCallbacks_t * pxCallbacks )
     if( xStatus == eBTStatusSuccess )
     {
 
-        nimble_port_init();
-
         ble_hs_cfg.reset_cb = bleprph_on_reset;
         ble_hs_cfg.sync_cb = bleprph_on_sync;
         ble_hs_cfg.store_status_cb = ble_store_util_status_rr;
+
         ble_store_config_init();
     }
     
@@ -568,8 +567,6 @@ BTStatus_t prvBtManagerCleanup()
 {
     esp_err_t xRet;
     BTStatus_t xStatus = eBTStatusSuccess;
-
-    nimble_port_deinit();
 
     xRet = esp_nimble_hci_and_controller_deinit();
     if( xRet != ESP_OK )
@@ -585,6 +582,7 @@ BTStatus_t prvBtManagerCleanup()
 
 BTStatus_t prvBTEnable( uint8_t ucGuestMode )
 {
+    nimble_port_init();
     nimble_port_freertos_init( ble_host_task );
     return eBTStatusSuccess;
 }
@@ -600,6 +598,7 @@ BTStatus_t prvBTDisable()
 
     if( rc == 0 )
     {
+        nimble_port_deinit();
         xStatus = eBTStatusSuccess;
     }
 


### PR DESCRIPTION
Mirror of aws amazon-freertos#1381
Refactor ESP init/deint/disable/enable functions

Description
-----------
* Move memory teardown functions outside.
* Have init/deinit enable/disable show consistent behavior.

Checklist:
----------



<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
